### PR TITLE
Interpret bash instead of assuming bash path

### DIFF
--- a/xeer1update
+++ b/xeer1update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #Automatically Update script for Xen Servers. Supports only 6.2 at the moment.
 #Start by downloading the xml file
 #bash xeer1


### PR DESCRIPTION
Very small change for bash environment

assuming /bin/bash isn't a great idea... use env to interpret bash binary
